### PR TITLE
change container approach - each language has a separate container now

### DIFF
--- a/docker/cpp.Dockerfile
+++ b/docker/cpp.Dockerfile
@@ -1,0 +1,7 @@
+# This is not a Dockerfile for the server. This is a Dockerfile for the containers that will execute the code.
+
+FROM alpine:3.21.3
+
+RUN apk add --no-cache build-base
+
+CMD ["sleep", "infinity"]

--- a/docker/java.Dockerfile
+++ b/docker/java.Dockerfile
@@ -1,0 +1,7 @@
+# This is not a Dockerfile for the server. This is a Dockerfile for the containers that will execute the code.
+
+FROM alpine:3.21.3
+
+RUN apk add --no-cache openjdk17
+
+CMD ["sleep", "infinity"]

--- a/docker/python.Dockerfile
+++ b/docker/python.Dockerfile
@@ -2,7 +2,6 @@
 
 FROM alpine:3.21.3
 
-RUN apk update
-RUN apk add --no-cache python3 build-base py3-pip openjdk8 nano
+RUN apk add --no-cache python3 py3-pip
 
-CMD [ "python3", "-m", "http.server" ]
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
Closes #1

Earlier, an alpine linux container would have all dependencies install for multi-language support. Now, each language has a separate dockerfile, reducing image size substantially. The task is assigned to a container based on the language the code is submitted in. If a user submits python code, it will get picked up by a python container.

Testing with java and cpp containers pending.